### PR TITLE
Submit multiple chunks concurrently to fill max_concurrent capacity

### DIFF
--- a/slurmgrid/monitor.py
+++ b/slurmgrid/monitor.py
@@ -193,26 +193,32 @@ def _update_single_chunk(
 
 
 def _submit_to_fill(state: State, config: RunConfig) -> None:
-    """Submit the next pending chunk if no chunks are currently active.
+    """Submit pending chunks to fill available task capacity.
 
-    Only one chunk is active at a time. Slurm's array %throttle controls
-    how many tasks run simultaneously within the chunk.
+    Submits chunks until adding another would exceed max_concurrent total
+    active tasks. Always submits at least one chunk if none are active
+    (ensures forward progress). For example, with max_concurrent=10000
+    and chunk_size=5000, up to 2 chunks run simultaneously.
 
     If no regular chunks are pending but there are retriable failures,
-    batch them into a single retry chunk and submit it.
+    batch them into retry chunks and submit those (only when all active
+    chunks have finished to avoid premature retries).
     """
-    if state.active_chunks():
-        return
     pending = state.pending_chunks()
-    if pending:
-        _submit_chunk(pending[0], state, config)
-        return
+    if not pending and not state.active_chunks():
+        # No regular pending chunks and nothing active — try retry batches.
+        _create_retry_batch(state, config)
+        pending = state.pending_chunks()
 
-    # No pending chunks — create a retry batch from accumulated failures
-    _create_retry_batch(state, config)
-    pending = state.pending_chunks()
-    if pending:
-        _submit_chunk(pending[0], state, config)
+    while pending:
+        active_tasks = state.active_job_count()
+        next_chunk = pending[0]
+        # Always submit if nothing is active (ensures forward progress).
+        # Otherwise only submit if we have remaining capacity.
+        if active_tasks > 0 and active_tasks + next_chunk.size > config.max_concurrent:
+            break
+        _submit_chunk(next_chunk, state, config)
+        pending = state.pending_chunks()
 
 
 def _create_retry_batch(state: State, config: RunConfig) -> None:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -80,10 +80,11 @@ class TestFullCycle(unittest.TestCase):
             return jid
         mock_slurm.sbatch.side_effect = fake_sbatch
 
-        # Submit initial batch — one chunk at a time
+        # Submit initial batch — fills to max_concurrent: both chunk_000 and
+        # chunk_001 submitted at once (7 + 7 = 14 == max_concurrent)
         _submit_to_fill(state, self.config)
-        self.assertEqual(mock_slurm.sbatch.call_count, 1)
-        self.assertEqual(state.active_job_count(), 7)
+        self.assertEqual(mock_slurm.sbatch.call_count, 2)
+        self.assertEqual(state.active_job_count(), 14)
 
         # Mock sacct: all tasks completed successfully
         def fake_sacct(job_ids):
@@ -98,17 +99,13 @@ class TestFullCycle(unittest.TestCase):
             return result
         mock_slurm.sacct_query.side_effect = fake_sacct
 
-        # First poll: chunk 0 completes, chunk 1 gets submitted
+        # First poll: chunks 0 and 1 complete together, chunk 2 gets submitted
         _poll_once(state, self.config)
         self.assertEqual(state.chunks["chunk_000"].status, "completed")
-        self.assertEqual(state.chunks["chunk_001"].status, "submitted")
-
-        # Second poll: chunk 1 completes, chunk 2 gets submitted
-        _poll_once(state, self.config)
         self.assertEqual(state.chunks["chunk_001"].status, "completed")
         self.assertEqual(state.chunks["chunk_002"].status, "submitted")
 
-        # Third poll: chunk 2 completes
+        # Second poll: chunk 2 completes, run is done
         _poll_once(state, self.config)
         self.assertEqual(state.chunks["chunk_002"].status, "completed")
         self.assertTrue(state.is_done())
@@ -126,9 +123,9 @@ class TestFullCycle(unittest.TestCase):
             return jid
         mock_slurm.sbatch.side_effect = fake_sbatch
 
-        # One chunk at a time
+        # Fills to max_concurrent: chunk_000 and chunk_001 submitted together
         _submit_to_fill(state, self.config)
-        self.assertEqual(mock_slurm.sbatch.call_count, 1)
+        self.assertEqual(mock_slurm.sbatch.call_count, 2)
 
         # Mock sacct: tasks 3 and 4 in chunk_000 fail
         def fake_sacct(job_ids):
@@ -149,19 +146,15 @@ class TestFullCycle(unittest.TestCase):
             return result
         mock_slurm.sacct_query.side_effect = fake_sacct
 
-        # Poll: chunk_000 partial failure, chunk_001 submitted next
+        # Poll: chunk_000 partial failure, chunk_001 completed, chunk_002 submitted
         # (retries are deferred until all regular chunks are done)
         _poll_once(state, self.config)
         self.assertEqual(state.chunks["chunk_000"].status, "partial_failure")
+        self.assertEqual(state.chunks["chunk_001"].status, "completed")
         self.assertEqual(len(state.failures), 2)
-        # No retry chunk yet — regular chunks take priority
+        # No retry chunk yet — chunk_002 is still pending
         retry_chunks = [c for c in state.chunks if "retry" in c]
         self.assertEqual(len(retry_chunks), 0)
-        self.assertEqual(state.chunks["chunk_001"].status, "submitted")
-
-        # Poll: chunk_001 completes, chunk_002 submitted
-        _poll_once(state, self.config)
-        self.assertEqual(state.chunks["chunk_001"].status, "completed")
         self.assertEqual(state.chunks["chunk_002"].status, "submitted")
 
         # Poll: chunk_002 completes, now retry batch is created and submitted


### PR DESCRIPTION
Previously _submit_to_fill exited immediately if any chunk was active, so chunks ran strictly one at a time. With chunk_size=5000 and max_concurrent=10000, this left half the cluster idle while waiting for stragglers to finish before the next chunk could start.

Now _submit_to_fill keeps submitting chunks as long as active_job_count + next_chunk.size <= max_concurrent, filling the available capacity on every poll.