### PR TITLE
Add --after-run to block stage 2 until stage 1 completes

### DIFF
--- a/slurmgrid/cli.py
+++ b/slurmgrid/cli.py
@@ -90,6 +90,11 @@ def main(argv: Optional[List[str]] = None) -> None:
     p_submit.add_argument("--no-shuffle", action="store_true",
                           help="Don't shuffle manifest rows before chunking "
                                "(default: shuffle for balanced chunks)")
+    p_submit.add_argument(
+        "--after-run", default=None, metavar="STATE_DIR",
+        help="Wait for a previous run to finish before submitting "
+             "(path to its state directory)",
+    )
     _add_slurm_args(p_submit)
 
     # --- resume ---
@@ -187,6 +192,11 @@ def cmd_submit(args: argparse.Namespace) -> None:
         log.error("Use 'resume' to continue, or choose a different --state-dir")
         sys.exit(1)
 
+    after_run = os.path.abspath(args.after_run) if args.after_run else None
+    if after_run and not state_exists(after_run):
+        log.error("--after-run state directory not found: %s", after_run)
+        sys.exit(1)
+
     # Resolve manifest path to absolute (it's referenced from sbatch scripts)
     manifest_path = os.path.abspath(args.manifest)
 
@@ -203,6 +213,7 @@ def cmd_submit(args: argparse.Namespace) -> None:
         max_runtime=args.max_runtime,
         dry_run=args.dry_run,
         shuffle=not args.no_shuffle,
+        after_run=after_run,
         slurm=slurm_config,
     )
 

--- a/slurmgrid/config.py
+++ b/slurmgrid/config.py
@@ -80,6 +80,7 @@ class RunConfig:
     max_runtime: Optional[int] = None  # Seconds; None means no limit
     dry_run: bool = False
     shuffle: bool = True
+    after_run: Optional[str] = None  # State dir of a run to wait for
     slurm: SlurmConfig = field(default_factory=SlurmConfig)
 
     @property

--- a/slurmgrid/monitor.py
+++ b/slurmgrid/monitor.py
@@ -27,6 +27,7 @@ from .state import (
     ChunkState,
     FailureRecord,
     State,
+    load_state,
     save_state,
 )
 
@@ -46,6 +47,10 @@ def run(state: State, config: RunConfig) -> State:
     start_time = time.monotonic()
 
     try:
+        # Wait for upstream dependency if specified
+        if config.after_run:
+            _wait_for_upstream(config)
+
         # Initial submission to fill available slots
         _submit_to_fill(state, config)
         save_state(state, config.state_dir)
@@ -76,6 +81,26 @@ def run(state: State, config: RunConfig) -> State:
                  config.state_dir)
 
     return state
+
+
+def _wait_for_upstream(config: RunConfig) -> None:
+    """Poll the upstream state directory until that run reports done."""
+    log.info("Waiting for upstream run at %s to complete...", config.after_run)
+    while True:
+        try:
+            prev = load_state(config.after_run)
+            if prev.is_done():
+                log.info("Upstream run complete, proceeding.")
+                return
+            s = prev.summary()
+            log.info(
+                "Upstream: %d/%d completed, %d active, %d pending",
+                s["completed_tasks"], s["total_jobs"],
+                s["active_tasks"], s["pending_tasks"],
+            )
+        except (OSError, ValueError) as e:
+            log.warning("Could not read upstream state: %s", e)
+        time.sleep(config.poll_interval)
 
 
 def _poll_once(state: State, config: RunConfig) -> None:

--- a/tests/slurm_integration/run_tests.py
+++ b/tests/slurm_integration/run_tests.py
@@ -390,6 +390,164 @@ def test_status_command(project_dir):
     return True
 
 
+def test_after_run(project_dir):
+    """Test: stage 2 waits for a still-running stage 1 before submitting."""
+    log("=" * 60)
+    log("TEST: after_run")
+    log("=" * 60)
+
+    tmpdir = make_shared_dir("test_after_run")
+    manifest1 = os.path.join(tmpdir, "manifest1.csv")
+    manifest2 = os.path.join(tmpdir, "manifest2.csv")
+    state_dir1 = os.path.join(tmpdir, "state1")
+    state_dir2 = os.path.join(tmpdir, "state2")
+
+    # Stage 1: 4 jobs that each sleep for a few seconds so stage 1 is still
+    # running when stage 2 starts.
+    create_manifest(manifest1, 4)
+    create_manifest(manifest2, 4)
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = project_dir
+    stage1_cmd = [
+        sys.executable, "-m", "slurmgrid", "submit",
+        "--manifest", manifest1,
+        "--command", "sleep 8 && echo done idx={idx}",
+        "--state-dir", state_dir1,
+        "--chunk-size", "5",
+        "--max-concurrent", "10",
+        "--max-retries", "0",
+        "--max-runtime", "180",
+        "--poll-interval", "5",
+        "--time", "00:05:00",
+    ]
+    log(f"Starting stage 1 in background: {' '.join(stage1_cmd)}")
+    stage1_proc = subprocess.Popen(
+        stage1_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        text=True, env=env,
+    )
+
+    # Wait for stage 1 to create its state file (meaning it has been submitted)
+    log("Waiting for stage 1 state file to appear...")
+    state1_json = os.path.join(state_dir1, "state.json")
+    for _ in range(60):
+        if os.path.isfile(state1_json):
+            break
+        time.sleep(1)
+    else:
+        log("FAIL: stage 1 state file never appeared")
+        stage1_proc.kill()
+        return False
+
+    # Confirm stage 1 is not yet done
+    state1_snapshot = load_state(state_dir1)
+    if all(c["status"] in ("completed", "partial_failure")
+           for c in state1_snapshot["chunks"].values()):
+        log("WARN: stage 1 finished before stage 2 could start — "
+            "try increasing sleep duration")
+        # This isn't a hard failure of the feature, just a race; carry on.
+
+    log("Stage 1 is running; starting stage 2 with --after-run")
+
+    # Stage 2 blocks until stage 1 is done, then runs its own jobs
+    result = run_slurmgrid(project_dir, [
+        "submit",
+        "--manifest", manifest2,
+        "--command", "echo stage2 idx={idx}",
+        "--state-dir", state_dir2,
+        "--chunk-size", "5",
+        "--max-concurrent", "10",
+        "--max-retries", "0",
+        "--max-runtime", "300",
+        "--poll-interval", "5",
+        "--time", "00:05:00",
+        "--after-run", state_dir1,
+    ])
+
+    # Also wait for the stage 1 background process to finish
+    try:
+        stdout1, stderr1 = stage1_proc.communicate(timeout=60)
+        for line in (stdout1 + stderr1).splitlines():
+            log(f"  stage1: {line}")
+    except subprocess.TimeoutExpired:
+        stage1_proc.kill()
+        log("FAIL: stage 1 background process timed out")
+        return False
+
+    if result.returncode != 0:
+        log("FAIL: stage 2 exited with non-zero")
+        _dump_debug_info(state_dir2)
+        return False
+    if stage1_proc.returncode != 0:
+        log(f"FAIL: stage 1 exited with non-zero ({stage1_proc.returncode})")
+        _dump_debug_info(state_dir1)
+        return False
+
+    state1 = load_state(state_dir1)
+    state2 = load_state(state_dir2)
+
+    completed1 = sum(1 for c in state1["chunks"].values()
+                     if c["status"] == "completed")
+    completed2 = sum(1 for c in state2["chunks"].values()
+                     if c["status"] == "completed")
+
+    log(f"Stage 1: {completed1}/{len(state1['chunks'])} chunks completed")
+    log(f"Stage 2: {completed2}/{len(state2['chunks'])} chunks completed")
+
+    if completed1 != len(state1["chunks"]):
+        log("FAIL: stage 1 did not fully complete")
+        return False
+    if completed2 != len(state2["chunks"]):
+        log("FAIL: stage 2 did not fully complete")
+        return False
+    if state2.get("failures"):
+        log("FAIL: stage 2 had unexpected failures")
+        return False
+
+    # Verify ordering: stage 2 must not have submitted until stage 1 was done.
+    # Compare sacct End times for stage 1 jobs against stage 2's submitted_at.
+    stage1_job_ids = [
+        c["slurm_job_id"] for c in state1["chunks"].values()
+        if c.get("slurm_job_id")
+    ]
+    stage2_submitted_at = min(
+        c["submitted_at"] for c in state2["chunks"].values()
+        if c.get("submitted_at")
+    )
+    log(f"Stage 2 first submitted_at: {stage2_submitted_at}")
+
+    if stage1_job_ids:
+        sacct_result = subprocess.run(
+            ["sacct", "--jobs=" + ",".join(stage1_job_ids),
+             "--format=JobID,End", "--parsable2", "--noheader"],
+            capture_output=True, text=True,
+        )
+        ordering_ok = True
+        for line in sacct_result.stdout.splitlines():
+            parts = line.strip().rstrip("|").split("|")
+            if len(parts) < 2:
+                continue
+            job_id, end_time = parts[0], parts[1]
+            # Skip batch/extern steps; only check array tasks (JobID contains _)
+            if "_" not in job_id:
+                continue
+            if not end_time or end_time in ("Unknown", "None"):
+                continue
+            # Both timestamps are UTC ISO; strip timezone suffix for comparison
+            end_norm = end_time.replace("T", " ")
+            sub_norm = stage2_submitted_at[:19].replace("T", " ")
+            log(f"  stage1 task {job_id} ended {end_norm}, stage2 submitted {sub_norm}")
+            if end_norm > sub_norm:
+                log(f"FAIL: stage 1 task {job_id} ended AFTER stage 2 submitted")
+                ordering_ok = False
+        if not ordering_ok:
+            return False
+        log("Ordering verified: all stage 1 jobs ended before stage 2 submitted")
+
+    log("PASS")
+    return True
+
+
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
@@ -413,6 +571,7 @@ def main():
         test_status_command,
         test_basic_submit_and_complete,
         test_failure_and_retry,
+        test_after_run,
     ]
 
     results = {}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -126,6 +126,7 @@ class TestCmdSubmitDryRun(unittest.TestCase):
                 preamble=None,
                 preamble_file=None,
                 no_shuffle=False,
+                after_run=None,
             )
             cmd_submit(args)
 
@@ -167,6 +168,7 @@ class TestCmdSubmitDryRun(unittest.TestCase):
                 job_name_prefix="sc", extra_sbatch=[], preamble=None,
                 preamble_file=None,
                 no_shuffle=False,
+                after_run=None,
             )
             with self.assertRaises(SystemExit):
                 cmd_submit(args)
@@ -195,6 +197,7 @@ class TestCmdSubmitDryRun(unittest.TestCase):
                 job_name_prefix="sc", extra_sbatch=[], preamble=None,
                 preamble_file=None,
                 no_shuffle=False,
+                after_run=None,
             )
             with self.assertRaises(SystemExit):
                 cmd_submit(args)
@@ -226,6 +229,7 @@ class TestCmdSubmitDryRun(unittest.TestCase):
                 job_name_prefix="sc", extra_sbatch=[], preamble=None,
                 preamble_file=None,
                 no_shuffle=False,
+                after_run=None,
             )
             cmd_submit(args)
             mock_max_array.assert_called_once()

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -15,6 +15,7 @@ from slurmgrid.monitor import (
     _submit_chunk,
     _submit_to_fill,
     _update_single_chunk,
+    _wait_for_upstream,
     run,
 )
 from slurmgrid.script import (
@@ -24,7 +25,7 @@ from slurmgrid.script import (
     write_sbatch_script,
 )
 from slurmgrid.slurm import SlurmError, TaskState, TaskStatus
-from slurmgrid.state import ChunkState, new_state, save_state
+from slurmgrid.state import ChunkState, new_state, save_state, load_state
 
 FIXTURES = os.path.join(os.path.dirname(__file__), "fixtures")
 
@@ -233,6 +234,115 @@ class TestRunLoop(unittest.TestCase):
 
         final = run(state, config)
         # Should not crash, just exit due to max_runtime
+
+
+class TestWaitForUpstream(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.upstream_dir = tempfile.mkdtemp()
+        self.config = RunConfig(
+            manifest=os.path.join(FIXTURES, "sample_manifest.csv"),
+            command="echo {alpha}",
+            state_dir=self.tmpdir,
+            chunk_size=5,
+            max_concurrent=10,
+            max_retries=0,
+            poll_interval=0,
+            after_run=self.upstream_dir,
+            slurm=SlurmConfig(),
+        )
+
+    def _make_upstream_state(self, done=False):
+        state = new_state(5, 5, 10, 0)
+        state.add_chunk("chunk_000", 5, {str(i): i for i in range(5)})
+        if done:
+            state.mark_submitted("chunk_000", "999")
+            state.mark_completed("chunk_000")
+            state.chunks["chunk_000"].completed_tasks = 5
+        save_state(state, self.upstream_dir)
+        return state
+
+    @patch("slurmgrid.monitor.time.sleep")
+    def test_returns_immediately_when_done(self, mock_sleep):
+        self._make_upstream_state(done=True)
+        _wait_for_upstream(self.config)
+        mock_sleep.assert_not_called()
+
+    @patch("slurmgrid.monitor.time.sleep")
+    def test_polls_until_done(self, mock_sleep):
+        upstream = self._make_upstream_state(done=False)
+
+        call_count = [0]
+        def complete_on_second_call(_):
+            call_count[0] += 1
+            if call_count[0] >= 1:
+                upstream.mark_submitted("chunk_000", "999")
+                upstream.mark_completed("chunk_000")
+                save_state(upstream, self.upstream_dir)
+        mock_sleep.side_effect = complete_on_second_call
+
+        _wait_for_upstream(self.config)
+        self.assertEqual(mock_sleep.call_count, 1)
+
+    @patch("slurmgrid.monitor.time.sleep")
+    def test_handles_unreadable_state(self, mock_sleep):
+        """If the upstream state file is temporarily unreadable, keep polling."""
+        upstream = self._make_upstream_state(done=False)
+
+        call_count = [0]
+        def fix_on_second_call(_):
+            call_count[0] += 1
+            if call_count[0] >= 1:
+                upstream.mark_submitted("chunk_000", "999")
+                upstream.mark_completed("chunk_000")
+                save_state(upstream, self.upstream_dir)
+        mock_sleep.side_effect = fix_on_second_call
+
+        # Corrupt the state file temporarily, then fix it on first sleep
+        import json
+        state_path = os.path.join(self.upstream_dir, "state.json")
+        with open(state_path, "w") as f:
+            f.write("not valid json")
+
+        # The first read will fail; the sleep side effect will write a valid state
+        _wait_for_upstream(self.config)
+        self.assertGreaterEqual(mock_sleep.call_count, 1)
+
+    @patch("slurmgrid.monitor.time.sleep")
+    @patch("slurmgrid.monitor.slurm")
+    def test_run_waits_for_upstream_before_submitting(self, mock_slurm, mock_sleep):
+        """run() should not submit any chunks until upstream is done."""
+        upstream = self._make_upstream_state(done=False)
+
+        # Set up a minimal runnable state for the current run
+        state = new_state(5, 5, 10, 0)
+        scripts_dir = os.path.join(self.tmpdir, "scripts")
+        os.makedirs(scripts_dir)
+        state.add_chunk("chunk_000", 5, {str(i): i for i in range(5)})
+        with open(os.path.join(scripts_dir, "chunk_000.sh"), "w") as f:
+            f.write("#!/bin/bash\necho hi\n")
+        save_state(state, self.tmpdir)
+
+        mock_slurm.sbatch.return_value = "101"
+        mock_slurm.sacct_query.return_value = {}
+
+        sleep_count = [0]
+        def complete_upstream_then_exit(_):
+            sleep_count[0] += 1
+            if sleep_count[0] == 1:
+                # Complete upstream on first sleep (during _wait_for_upstream)
+                upstream.mark_submitted("chunk_000", "999")
+                upstream.mark_completed("chunk_000")
+                save_state(upstream, self.upstream_dir)
+            else:
+                raise GracefulExit()
+        mock_sleep.side_effect = complete_upstream_then_exit
+
+        self.config.max_runtime = None
+        run(state, self.config)
+
+        # sbatch should have been called after upstream completed
+        mock_slurm.sbatch.assert_called_once()
 
 
 class TestInstallSignalHandlers(unittest.TestCase):


### PR DESCRIPTION
New flag: slurmgrid submit --after-run STATE_DIR

The monitor polls the upstream run's state file until is_done() returns true before submitting any chunks. Progress of the upstream run is logged each poll interval. Handles temporarily unreadable state files gracefully.