### PR TITLE
Fix capacity tracking to use remaining tasks; add --serial-chunks

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,8 +192,11 @@ Inspect the generated scripts in `./sc_state/scripts/` to verify correctness.
    magnitude faster than submitting jobs individually.
 
 4. **Monitoring**: The tool polls `sacct` to track job status. Multiple chunks
-   run concurrently as capacity allows (up to `--max-concurrent` total tasks);
-   new chunks are submitted as running ones complete.
+   run concurrently: a new chunk is submitted whenever the number of remaining
+   (incomplete) tasks across active chunks drops enough to fit another chunk
+   within `--max-concurrent`. Use `--serial-chunks` to run one chunk at a time
+   instead, which is useful when tasks compete for an external resource (e.g.,
+   API rate limits) beyond what Slurm's `%throttle` controls.
 
 5. **Retries**: When all regular chunks are done, failed tasks are batched
    into a single retry chunk and resubmitted, up to `--max-retries` per task.
@@ -254,6 +257,7 @@ sc_state/
 | `--extra-sbatch` | | Extra `#SBATCH` flags (repeatable) |
 | `--after-run` | | Wait for a previous run to finish before submitting (path to its state directory) |
 | `--self-resubmit` | false | On `--max-runtime` exit, automatically sbatch a new resume job |
+| `--serial-chunks` | false | Submit one chunk at a time (wait for full completion before submitting the next) |
 | `--config` | | YAML config file; any option above can be set as a key |
 
 ## Requirements

--- a/slurmgrid/cli.py
+++ b/slurmgrid/cli.py
@@ -105,6 +105,12 @@ def main(argv: Optional[List[str]] = None) -> None:
         help="When --max-runtime is hit, automatically resubmit a resume job "
              "so monitoring continues without manual intervention",
     )
+    p_submit.add_argument(
+        "--serial-chunks", action="store_true",
+        help="Submit one chunk at a time; wait for it to fully complete before "
+             "submitting the next. Use when tasks compete for an external resource "
+             "(e.g., API rate limits) beyond what Slurm's %%throttle controls",
+    )
     _add_slurm_args(p_submit)
 
     # --- resume ---
@@ -229,6 +235,7 @@ def cmd_submit(args: argparse.Namespace) -> None:
         shuffle=not args.no_shuffle,
         after_run=after_run,
         self_resubmit=args.self_resubmit,
+        serial_chunks=args.serial_chunks,
         slurm=slurm_config,
     )
 

--- a/slurmgrid/config.py
+++ b/slurmgrid/config.py
@@ -82,6 +82,7 @@ class RunConfig:
     shuffle: bool = True
     after_run: Optional[str] = None  # State dir of a run to wait for
     self_resubmit: bool = False  # Resubmit as a new Slurm job on max_runtime exit
+    serial_chunks: bool = False  # Submit one chunk at a time (for rate-limited workloads)
     slurm: SlurmConfig = field(default_factory=SlurmConfig)
 
     @property

--- a/slurmgrid/monitor.py
+++ b/slurmgrid/monitor.py
@@ -303,10 +303,15 @@ def _update_single_chunk(
 def _submit_to_fill(state: State, config: RunConfig) -> None:
     """Submit pending chunks to fill available task capacity.
 
-    Submits chunks until adding another would exceed max_concurrent total
-    active tasks. Always submits at least one chunk if none are active
-    (ensures forward progress). For example, with max_concurrent=10000
-    and chunk_size=5000, up to 2 chunks run simultaneously.
+    By default, submits chunks as long as active remaining tasks +
+    next_chunk.size <= max_concurrent, always submitting at least one if
+    nothing is active. "Remaining tasks" counts only incomplete tasks in
+    active chunks, so capacity opens up as tasks finish within a chunk
+    rather than waiting for an entire chunk to complete.
+
+    With --serial-chunks, only one chunk is active at a time. Use this
+    when tasks compete for an external resource (e.g., API rate limits)
+    where the Slurm %throttle alone isn't sufficient.
 
     If no regular chunks are pending but there are retriable failures,
     batch them into retry chunks and submit those (only when all active
@@ -319,6 +324,8 @@ def _submit_to_fill(state: State, config: RunConfig) -> None:
         pending = state.pending_chunks()
 
     while pending:
+        if config.serial_chunks and state.active_chunks():
+            break
         active_tasks = state.active_job_count()
         next_chunk = pending[0]
         # Always submit if nothing is active (ensures forward progress).

--- a/slurmgrid/state.py
+++ b/slurmgrid/state.py
@@ -86,8 +86,8 @@ class State:
         ]
 
     def active_job_count(self) -> int:
-        """Total number of in-flight tasks across all active chunks."""
-        return sum(c.size for c in self.active_chunks())
+        """Remaining (incomplete) tasks across all active chunks."""
+        return sum(c.size - c.completed_tasks for c in self.active_chunks())
 
     def is_done(self) -> bool:
         """True if all chunks are completed or permanently failed."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -168,6 +168,7 @@ class TestCmdSubmitDryRun(unittest.TestCase):
                 no_shuffle=False,
                 after_run=None,
                 self_resubmit=False,
+                serial_chunks=False,
                 config=None,
             )
             cmd_submit(args)
@@ -212,6 +213,7 @@ class TestCmdSubmitDryRun(unittest.TestCase):
                 no_shuffle=False,
                 after_run=None,
                 self_resubmit=False,
+                serial_chunks=False,
                 config=None,
             )
             with self.assertRaises(SystemExit):
@@ -243,6 +245,7 @@ class TestCmdSubmitDryRun(unittest.TestCase):
                 no_shuffle=False,
                 after_run=None,
                 self_resubmit=False,
+                serial_chunks=False,
                 config=None,
             )
             with self.assertRaises(SystemExit):
@@ -277,6 +280,7 @@ class TestCmdSubmitDryRun(unittest.TestCase):
                 no_shuffle=False,
                 after_run=None,
                 self_resubmit=False,
+                serial_chunks=False,
                 config=None,
             )
             cmd_submit(args)


### PR DESCRIPTION
active_job_count() was counting the full size of each active chunk regardless of how many tasks had already completed. With chunk_size=5000 and max_concurrent=10000, this meant a new chunk was only submitted when an entire previous chunk fully finished, leaving the cluster steadily draining toward zero instead of staying near capacity.

Fix: count remaining (size - completed_tasks) instead of full size. A new chunk is now submitted once enough tasks have completed across active chunks to make room, typically partway into a chunk's run rather than waiting for full completion.

Add --serial-chunks flag for workloads where only one chunk should be active at a time (e.g., tasks hitting an external API where the Slurm %throttle alone isn't sufficient to control the rate).